### PR TITLE
Adds ruby gem local lib to the loadpath on the CLI tools

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,6 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+lib_path = File.expand_path("../lib", __dir__)
+$LOAD_PATH.unshift(lib_path) unless $LOAD_PATH.include?(lib_path)
+
 require "bundler/setup"
 require "manifolds"
 

--- a/bin/manifolds
+++ b/bin/manifolds
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
-
 # frozen_string_literal: true
 
-require File.expand_path("../lib/manifolds", __dir__)
+lib_path = File.expand_path("../lib", Dir.pwd)
+$LOAD_PATH.unshift(lib_path) unless $LOAD_PATH.include?(lib_path)
+
+require "manifolds/cli"
 
 Manifolds::CLI.start(ARGV)


### PR DESCRIPTION
By injecting the gem's lib into the load path it forces the executable to use the version of manifolds it is contained within instead of the system manifolds.

This is a best practice and makes gem development easier.