### PR TITLE
add formatter output to rspec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
+--format documentation
 --require spec_helper
 --color


### PR DESCRIPTION
I much like seeing spec docs by default. 